### PR TITLE
Fix argument format of example code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ sudo apt-get install libcurl4-openssl-dev
 ## Usage
 
 ```swift
-let result = try HTTPClient.sendRequest("GET", "https://google.com")
+let result = try HTTPClient.sendRequest(method: "GET", url: "https://google.com")
 print(result.statusCode, result.body)
 ```
 


### PR DESCRIPTION
## 背景

こんにちは。[Tokyo Server Side Swift Meetup #7 - connpass](https://tokyo-ss-swift.connpass.com/event/56630/) の発表でこのリポジトリが紹介されていたので、Server-Side Swift の勉強も兼ねて、swift-seeurl を試してみました。

README を見てサンプルコードを動かしてみたのですが、以下のようにビルドしようとしてみたところ、エラーが出て失敗してしまいました。

```bash
swift build -Xlinker -L/usr/lib -Xlinker -lcurl
```

```
Compile Swift Module 'server_side_swift_example' (1 sources)
/Users/r7kamura/src/github.com/r7kamura/server-side-swift-example/Sources/main.swift:3:40: error: missing argument labels 'method:url:' in call
let result = try HTTPClient.sendRequest("GET", "https://google.com")
                                      ^
                                       method:  url:
<unknown>:0: error: build had 1 command failures
error: exit(1): /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-build-tool -f /Users/r7kamura/src/github.com/r7kamura/server-side-swift-example/.build/debug.yaml
```

見たところ `HTTPClient.sendRequest` の引数の与え方が間違っているように見えたので、修正して Pull Request を送ってみました。

## 試した環境

ちなみに、以下のような環境で試しました。

```bash
swift --version
```

```
Apple Swift version 3.1 (swiftlang-802.0.53 clang-802.0.42)
Target: x86_64-apple-macosx10.9
```

Swift を触り始めてまた日が浅いので、何か勘違いをしているところがあるかもしれません。その場合は、遠慮なく Close して頂いて結構です 👍 